### PR TITLE
Hide shows that have already started.

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,3 @@
 * Display shows on some kind of timeline
-* Only display shows AFTER the current time, grey out ones before
+* ~~Only display shows AFTER the current time, grey out ones before~~
 * Add an AJAX loader until page is able to render

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -11,3 +11,7 @@ header {
   display: block;
   margin: 50px auto
 }
+
+.hide {
+  display: none;
+}

--- a/src/tv/core.cljs
+++ b/src/tv/core.cljs
@@ -3,7 +3,7 @@
   (:require [clojure.string :refer [blank? lower-case]]
             [cljs.core.async :refer [<! timeout]]
             [rum :refer-macros [defc]]
-            [tv.utils :refer [get-json! format-date get-weekday]]))
+            [tv.utils :refer [get-json! format-date get-weekday get-date-classes]]))
 
 (def state (atom {}))
 
@@ -24,7 +24,7 @@
 (defc tv-schedule < rum/static [schedule]
   [:section#tv-schedule.container.animated.fadeIn
    (for [{:keys [description originalTitle startTime title]} schedule]
-     [:div.tv-show
+     [:div.tv-show {:class (get-date-classes startTime)}
       [:h2 title
        (if-not (or (blank? originalTitle)
                    (= (lower-case originalTitle) (lower-case title)))

--- a/src/tv/utils.cljs
+++ b/src/tv/utils.cljs
@@ -4,6 +4,9 @@
             [cljs.core.async :refer [chan put!]]
             [cognitect.transit :as transit]))
 
+(defn get-date-classes [date]
+  (if (> (js/moment date) (js/moment)) "" "hide"))
+
 (defn- parse-json [json]
   (let [reader (transit/reader :json)]
     (keywordize-keys (transit/read reader json))))


### PR DESCRIPTION
Hey I hope you like pull requests! I've been meaning to take a stab at "real life" clojure and somebody pointed me to your repos recently. It's awesome stuff you got here :+1:

So this patch will add a `.hide` css class to all `.tv-show` elements whose start time is less than `now()` as is defined by moment.js and then there is a style change that will hide the elements that have the class `.hide`.

If you don't mind more PRs I'd love to play more with clojure :)

Thanks